### PR TITLE
Reduce the number of CI runs

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -11,9 +11,15 @@
 # succeed.
 name: Check and document build requirements for Sphinx venv
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  push:
+    paths:
+      - 'conf.py'
+      - 'custom_conf.py'
+  pull_request:
+    paths:
+      - 'conf.py'
+      - 'custom_conf.py'
+  workflow_dispatch:
 
 
 concurrency:


### PR DESCRIPTION
The check documentation and build requirements for Sphinx venv / build runs multiple times whenever a commit is pushed to a branch and a PR is opend from that branch. Reduce the number of CI runs by only running on pushes to the main branch or on a pull request, but not both.