### PR TITLE
Update build dependencies

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -44,7 +44,8 @@ jobs:
             libxslt1-dev \
             make \
             python3-venv \
-            rustc
+            rustc \
+            libtiff5-dev libjpeg8-dev libopenjp2-7-dev zlib1g-dev libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk libharfbuzz-dev libfribidi-dev libxcb1-dev
 
       - name: Build Sphinx venv
         run: |


### PR DESCRIPTION
Recent builds began failing due to inability to build pillow wheels. Additional dependencies are required. This mirrors changes from the sphinx-docs-starter-pack.