### PR TITLE
Update tutorial information

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -1,5 +1,3 @@
-:relatedlinks: [Diátaxis](https://diataxis.fr/)
-
 .. _home:
 
 Canonical OpenStack documentation
@@ -32,9 +30,9 @@ experience.
 
 ..  grid:: 1 1 2 2
 
-   ..  grid-item:: :doc:`Tutorial <tutorial/index>`
+   ..  grid-item:: :doc:`Tutorials <tutorial/index>`
 
-       **Start here**: a hands-on introduction to Example Product for new users
+       **Start here**: a hands-on introduction to Canonical OpenStack for new users
 
    ..  grid-item:: :doc:`How-to guides <how-to/index>`
 
@@ -53,8 +51,7 @@ experience.
 
 ---------
 
-Community and commercial usage
-------------------------------
+.. rubric:: :h2:`Community and commercial usage`
 
 Canonical OpenStack is based on Sunbeam - an open source project that warmly
 welcomes a free-of-charge usage, constructive feedback, community discussions

--- a/tutorial/index.rst
+++ b/tutorial/index.rst
@@ -1,8 +1,13 @@
 Tutorials
 =========
 
-Index
------
+This section of our documentation helps you learn how to install and use your
+Canonical OpenStack cloud. These tutorials should are aimed at helping users at
+the beginning their OpenStack journey and will guide you through various activities
+that are key to understand when using OpenStack.
+
+The tutorials are designed to take you on a progression, from installing an all-in-one
+OpenStack cloud to leveraging services that allow you to create and manage cloud resources.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Add some commentary to the base tutorials page to give the user some context as to which tutorials are available. Additionally, update some of the home page as well to refer to tutorials and use rubric instead of heading.