### PR TITLE
Bump minimum storage requirements for single node

### DIFF
--- a/tutorial/get-started-with-openstack.rst
+++ b/tutorial/get-started-with-openstack.rst
@@ -20,7 +20,7 @@ You will only need one dedicated physical machine with:
 
 * 4+ core amd64 processor
 * minimum of 16 GiB of RAM
-* minimum of 50 GiB SSD storage on the ``rootfs`` partition
+* minimum of 100 GiB SSD storage on the ``rootfs`` partition
 * fresh Ubuntu Desktop 24.04 LTS installed
 * unlimited access to the Internet
 


### PR DESCRIPTION
A minimum of 75G is required to have a functional single node. Set it to 100G to ensure the deployment can last a bit more in time, and have a little room for local storage on VMs.