### PR TITLE
Add component base minimum memory sizing

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -45,6 +45,7 @@ namespace
 namespaces
 NodePort
 Numbat
+NVMe
 observability
 OEM
 OIF
@@ -67,6 +68,7 @@ subdirectories
 subfolders
 subtree
 synchronized
+SunbeamD
 UA
 Ubuntu
 UCA

--- a/how-to/install/install-canonical-openstack-using-canonical-maas.rst
+++ b/how-to/install/install-canonical-openstack-using-canonical-maas.rst
@@ -40,7 +40,7 @@ You will need:
   node(s), with:
 
   * hardware specifications matching minimum hardware specifications for the *MAAS* node as
-    documented under the :doc:`Enterprise requirements</reference/enterprise-requirements>` section
+    documented in the `Canonical MAAS installation requirements`_.
   * fresh Ubuntu Server 24.04 LTS installed
  
 * one (or at least three for full HA) dedicated virtual machine(s), running on the *Governor*

--- a/reference/enterprise-requirements.rst
+++ b/reference/enterprise-requirements.rst
@@ -29,8 +29,9 @@ applies:
 |                       |                       | storage service       |
 +-----------------------+-----------------------+-----------------------+
 
-[note] **Note:** A single-node deployment has no resilience and has
-limited performance. [/note]
+.. note ::
+    A single-node deployment has no resilience and has
+    limited performance.
 
 Multi-node
 ----------
@@ -58,5 +59,35 @@ applies:
 |                       |                       | services              |
 +-----------------------+-----------------------+-----------------------+
 
-[note] **Note:** Three nodes are required for multi-node operation.
-[/note]
+.. note ::
+    Three nodes are required for multi-node operation.
+
+Role Based Minimum Memory Sizing
+--------------------------------
+
+For multi-node deployments the following minimum component memory sizing may be
+used to size each node based on the roles it hosts within the deployment:
+
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Component          | Kubernetes | Ceph OSD      | Ceph MON/MGR | Ceph RGW | Control Plane | SunbeamD | Juju Controller | Sunbeam Client |
++====================+============+===============+==============+==========+===============+==========+=================+================+
+| Control            | 4 GiB      |               |              |          | 10 GiB        |          |                 |                |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Compute            |            |               |              |          | 1 GiB         |          |                 |                |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Storage            |            | 5 GiB per OSD | 2 GiB        | 2 GiB    |               |          |                 |                |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Cloud              | 4 GiB      | 5 GiB per OSD | 2 GiB        | 2 GiB    | 11 GiB        |          |                 |                |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Sunbeam Controller |            |               |              |          |               | 4 GiB    |                 |                |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Sunbeam Client     |            |               |              |          |               |          |                 | 1 GiB          |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+| Juju Controller    |            |               |              |          |               |          | 4 GiB           |                |
++--------------------+------------+---------------+--------------+----------+---------------+----------+-----------------+----------------+
+
+.. note ::
+    For Ceph components, the scale of the deployment will have an
+    impact on the memory footprint for MON/MGR daemons (3 nodes) and more memory and
+    cores may be needed per Ceph OSD if using NVMe drives instead of SSD of spinning
+    disks.

--- a/reuse/links.txt
+++ b/reuse/links.txt
@@ -16,5 +16,6 @@
 .. _Canonical Kubernetes: https://ubuntu.com/kubernetes
 .. _Canonical OpenStack: https://canonical.com/openstack
 .. _Canonical MAAS: https://maas.io/
+.. _Canonical MAAS installation requirements: https://maas.io/docs/installation-requirements
 
 .. _Multipass: https://multipass.run


### PR DESCRIPTION
Add role/component based minimum memory sizing to enable users to calculate what footprints will be used in a multi-node deployment.