### PR TITLE
Document new nics field

### DIFF
--- a/reference/manifest-file-reference.rst
+++ b/reference/manifest-file-reference.rst
@@ -67,7 +67,13 @@ supported in channel ``2023.2/edge`` of the **openstack** snap. [/note]
 
      # External networking
      external_network:
-       nic: <interface-name>
+       nic: <interface-name> # deprecated
+       nics:
+         <node-hostname>: <interface-name>
+         # Examples:
+         # sunbeam-1.localdomain: enp5s0
+         # sunbeam-2.localdomain: enp8s0
+         # sunbeam-3.localdomain: eno3
        # CIDR of OpenStack external network
        cidr: <cidr>
        # IP address of default gateway for external network


### PR DESCRIPTION
Sunbeam now supports a hostname/nic mapping to allow configuring a different compute nic per host.

Old field nic is deprecated and acts as fallback.