### PR TITLE
docs: Fix documentation note tags and other issues

### DIFF
--- a/explanation/deployment-manifest.rst
+++ b/explanation/deployment-manifest.rst
@@ -11,8 +11,9 @@ Manifests are supported by the following commands:
 -  ``sunbeam configure``
 -  ``sunbeam enable``
 
-[note type=“positive”] **Note:** For a how-to on using manifests see
-:doc:`Managing deployment manifests </how-to/misc/managing-deployment-manifests>`. [/note]
+.. note::
+   For a how-to on using manifests see
+   :doc:`Managing deployment manifests </how-to/misc/managing-deployment-manifests>`.
 
 A manifest file
 ---------------
@@ -145,6 +146,6 @@ Option     Description
 
 This section is for demonstration and development purposes only.
 
-[note type=“caution”] **Caution:** There is significant risk of
-misconfiguration when using a local Terraform plan due to the fact that
-Sunbeam depends heavily on the plan variables. [/note]
+.. caution::
+   There is significant risk of misconfiguration when using a local Terraform
+   plan due to the fact that Sunbeam depends heavily on the plan variables.

--- a/explanation/network-traffic-isolation-with-maas.rst
+++ b/explanation/network-traffic-isolation-with-maas.rst
@@ -8,12 +8,12 @@ multi-network environment, where each of these cloud networks is coupled
 with specific cloud activity. It does this through the integration of
 Juju network spaces.
 
-[note type=“note”] **Network space:** A `Juju <https://juju.is>`__
-object that abstracts away the
-`OSI <https://en.wikipedia.org/wiki/OSI_model>`__ Layer 3 network
-concepts. A space is created on a backing cloud (e.g. MAAS) to represent
-one or more subnets. The purpose of a space is to allow for user-defined
-network traffic segmentation. [/note]
+.. note::
+   A `Juju <https://juju.is>`__ object that abstracts away the
+   `OSI <https://en.wikipedia.org/wiki/OSI_model>`__ Layer 3 network
+   concepts. A space is created on a backing cloud (e.g. MAAS) to represent
+   one or more subnets. The purpose of a space is to allow for user-defined
+   network traffic segmentation.
 
 Traffic isolation is implemented at the discretion of the cloud
 architect, where the degree of isolation is dependent upon the number of
@@ -27,10 +27,10 @@ Sunbeam. The space:network mappings are done at the Sunbeam level.
 In the case of an environment consisting of a sole subnet, each cloud
 network will be mapped to the same space.
 
-[note type=“note”] **Note:** The
-:doc:`Install Canonical OpenStack using Canonical MAAS
-</how-to/install/install-canonical-openstack-using-canonical-maas>`
-page shows how to use Canonical OpenStack with MAAS. [/note]
+.. note::
+   The :doc:`Install Canonical OpenStack using Canonical MAAS
+   </how-to/install/install-canonical-openstack-using-canonical-maas>`
+   page shows how to use Canonical OpenStack with MAAS.
 
 Cloud networks
 --------------

--- a/explanation/service-endpoint-encryption.rst
+++ b/explanation/service-endpoint-encryption.rst
@@ -9,9 +9,9 @@ method for the creation and distribution of TLS certificates. Canonical
 OpenStack supports enabling TLS via the Traefik application, which is the
 ingress point for all service endpoints.
 
-[note type=“info”] **Note:** Currently, only the TLS CA feature method
-is supported. This feature only works with certificates signed by an
-external Certificate Authority. [/note]
+.. note::
+   Currently, only the TLS CA feature method is supported. This feature only
+   works with certificates signed by an external Certificate Authority.
 
 TLS CA feature
 --------------
@@ -19,8 +19,9 @@ TLS CA feature
 The TLS CA feature is the method to use for deployments that use a third
 party CA for certificates.
 
-[note type=“caution”] **Note:** This feature is currently only supported
-in channel ``2023.2/edge`` of the **openstack** snap. [/note]
+.. caution::
+   This feature is currently only supported in channel ``2023.2/edge`` of the
+   **openstack** snap.
 
 .. tip::
    For a how-to on using the TLS CA feature see :doc:`Implement TLS using a third-party CA

--- a/how-to/features/caas.rst
+++ b/how-to/features/caas.rst
@@ -145,8 +145,8 @@ Check cluster list status using the following command:
    | 27eba31c-66a5-4efe-8373-49dd186567e6 | sunbeam-k8s-ovn | sunbeam |          1 |            1 | CREATE_COMPLETE | HEALTHY       |
    +--------------------------------------+-----------------+---------+------------+--------------+-----------------+---------------+
 
-[note type=“info”] **Note:** You may need to wait a few minutes before
-the cluster is ready. [/note]
+.. note::
+   You may need to wait a few minutes before the cluster is ready.
 
 Check cluster status using the following command:
 

--- a/how-to/features/images-sync.rst
+++ b/how-to/features/images-sync.rst
@@ -4,8 +4,9 @@ Images Sync
 This feature deploys OpenStack Images Sync, a tool for importing
 images from a SimpleStreams source to the OpenStack Glance image service.
 
-[note type=“info”] **Note:** This feature is currently only supported in
-channel ``2024.1/edge`` of the **openstack** snap. [/note]
+.. note::
+   This feature is currently only supported in channel ``2024.1/edge`` of the
+   **openstack** snap.
 
 Enable Images Sync
 ------------------
@@ -25,9 +26,9 @@ To disable Images Sync, run the following command:
 
    sunbeam disable images-sync
 
-[note type=“caution”] **Caution**: Disabling Images Sync will **not**
-remove images that have been previously imported from the Glance image
-service. [/note]
+.. caution::
+   **Caution**: Disabling Images Sync will **not** remove images that have been
+   previously imported from the Glance image service.
 
 Usage
 -----

--- a/how-to/features/ldap.rst
+++ b/how-to/features/ldap.rst
@@ -6,8 +6,9 @@ This feature integrates the OpenStack
 external LDAP service. Effectively, the feature maps LDAP-based users to
 cloud users via an OpenStack domain.
 
-[note type=“caution”] **Note:** This feature is currently only supported
-in channel ``2023.2`` of the **openstack** snap. [/note]
+.. caution::
+   This feature is currently only supported in channel ``2023.2`` of the
+   **openstack** snap.
 
 Enabling LDAP
 -------------
@@ -114,8 +115,8 @@ To remove an LDAP domain:
 
    sunbeam ldap remove-domain <domain-name>
 
-[note type=“important”] **Important:** Since configuration
-(e.g. OpenStack projects) could have been made to the domain after it
-was added, the ``remove-domain`` command only removes the LDAP
-connection. To completely remove the domain, the ``openstack`` CLI
-should be used (i.e. ``openstack domain delete``). [/note]
+.. important::
+   Since configuration (e.g. OpenStack projects) could have been made to the
+   domain after it was added, the ``remove-domain`` command only removes the
+   LDAP connection. To completely remove the domain, the ``openstack`` CLI
+   should be used (i.e. ``openstack domain delete``).

--- a/how-to/features/observability.rst
+++ b/how-to/features/observability.rst
@@ -108,11 +108,10 @@ Sample output:
    admin-password: ******
    url: http://10.20.21.13/observability-grafana
 
-[note type=“note” status=“Information”] Only the initial admin password
-is displayed in the above action. If the admin password is changed using
-the Grafana UI, a message
-``Admin password has been changed by an administrator`` will be
-displayed. [/note]
+.. note::
+   Only the initial admin password is displayed in the above action. If the
+   admin password is changed using the Grafana UI, a message
+   ``Admin password has been changed by an administrator`` will be displayed.
 
 Login Grafana dashboard
 -----------------------
@@ -141,8 +140,9 @@ You can now look at the different dashboards configured.
 Dashboard
 ---------
 
-[note type=“info”] **Note:** Dashboard is currently only supported in
-channel ``2023.2`` of the **:spelling:ignore:`openstack`** snap. [/note]
+.. note::
+   Dashboard is currently only supported in channel ``2023.2`` of the
+   **:spelling:ignore:`openstack`** snap.
 
 OpenStack Service Overview dashboard
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -203,12 +203,12 @@ given node.
 .. figure:: grafana-days-until-threshold.png
    :alt: Days until resource consumption dashboard
 
-[note type=“note” status=“Note”] You can filter the nodes using the
-multi-select dropdown menu: **Hostname**. [/note]
+.. note::
+   You can filter the nodes using the multi-select dropdown menu: **Hostname**.
 
-[note type=“note” status=“Note”] The 90% threshold and the 360 days of
-estimation can also be changed using the dropdown menu: **Resource Usage
-Threshold** and **Days of Estimation**. [/note]
+.. note::
+   The 90% threshold and the 360 days of estimation can also be changed using
+   the dropdown menu: **Resource Usage Threshold** and **Days of Estimation**.
 
 Disk usage
 ^^^^^^^^^^

--- a/how-to/features/tls-ca.rst
+++ b/how-to/features/tls-ca.rst
@@ -7,8 +7,8 @@ It does this by interfacing with the existing Traefik instances in the
 cloud. A Traefik instance is associated with either public or private
 cloud traffic.
 
-[note type=“note”] **Note:** TLS CA is currently the only way to enable
-TLS in Canonical OpenStack. [/note]
+.. note::
+   TLS CA is currently the only way to enable TLS in Canonical OpenStack.
 
 Enable TLS CA
 -------------

--- a/how-to/features/validation.rst
+++ b/how-to/features/validation.rst
@@ -122,8 +122,8 @@ to an empty string:
 
    sunbeam configure validation schedule=""
 
-[note type=“info”] **Note:** Due to performance considerations,
-intervals under 15 minutes are not supported. [/note]
+.. note::
+   Due to performance considerations, intervals under 15 minutes are not supported.
 
 Results will be displayed in a validation-specific Grafana dashboard and
 alerts will be fired when periodic checks fail. For more information on

--- a/how-to/misc/implement-tls-using-a-third-party-ca.rst
+++ b/how-to/misc/implement-tls-using-a-third-party-ca.rst
@@ -9,8 +9,9 @@ Authority for your certificates.
    :doc:`Service endpoint encryption </explanation/service-endpoint-encryption>`
    page.
 
-[note type=“caution”] **Note:** This feature is currently only supported
-in channel ``2023.2/edge`` of the **openstack** snap. [/note]
+.. caution::
+   This feature is currently only supported in channel ``2023.2/edge`` of the
+   **openstack** snap.
 
 Enable the TLS CA feature
 -------------------------
@@ -92,9 +93,9 @@ You’ll need to supply the Certificate Authority (identified in the
 ``enable`` command) with the CSRs. Do this via the certificate authority's
 web site.
 
-[note type=“info”] **Note:** Ensure the TLS certificate from CA has
-Subject Alternative Name with IP Address of the service if DNS names are
-not used. [/note]
+.. note::
+   Ensure the TLS certificate from CA has Subject Alternative Name with IP
+   Address of the service if DNS names are not used.
 
 Input TLS certificates
 ----------------------

--- a/how-to/misc/managing-deployment-manifests.rst
+++ b/how-to/misc/managing-deployment-manifests.rst
@@ -1,12 +1,13 @@
 This page shows how to manage deployment manifests. For an overview of
 manifests, see the :doc:`Deployment manifest </explanation/deployment-manifest>` page.
 
-[note type=“caution”] **Note:** This feature is currently only supported
-in channel ``2023.2/edge`` and later of the **openstack** snap. [/note]
+.. caution::
+   This feature is currently only supported in channel ``2023.2/edge`` and
+   later of the **openstack** snap.
 
-[note type=“info”] **Note:** Looking to use a manifest from an edge
-deployment ? Take a look at `Manifest for non-stable
-deployments <#manifest-for-non-stable-deployments-4>`__. [/note]
+.. note::
+   Looking to use a manifest from an edge deployment? Take a look at
+   `Manifest for non-stable deployments <#manifest-for-non-stable-deployments-4>`__.
 
 List manifests
 --------------
@@ -103,8 +104,9 @@ To specify a manifest during a cluster refresh (update) process:
 Only components managed via Terraform can be changed (bootstrap options
 will be immutable at this point).
 
-[note type=“note”] **Note:** A manifest update must be accompanied by a
-complete manifest file (i.e. not a delta). [/note]
+.. note::
+   A manifest update must be accompanied by a complete manifest file
+   (i.e. not a delta).
 
 Feature enablement
 ~~~~~~~~~~~~~~~~~~
@@ -118,5 +120,6 @@ feature:
 
 A post-enablement invocation implies a manifest update.
 
-[note type=“note”] **Note:** A manifest update must be accompanied by a
-complete manifest file (i.e. not a delta). [/note]
+.. note::
+   A manifest update must be accompanied by a complete manifest file
+   (i.e. not a delta).

--- a/how-to/misc/using-an-existing-juju-controller.rst
+++ b/how-to/misc/using-an-existing-juju-controller.rst
@@ -12,8 +12,9 @@ Register the Juju controller
 :doc:`Register an existing Juju controller </how-to/misc/manage-external-juju-controllers>`
 in Sunbeam.
 
-[note type=“note”] **Note:** Ensure a dedicated user is created in the
-external Juju controller and has ``superuser`` permissions granted on this controller. [/note]
+.. note::
+   Ensure a dedicated user is created in the external Juju controller and has
+   ``superuser`` permissions granted on this controller.
 
 Bootstrap with registered Juju controller
 -----------------------------------------

--- a/how-to/operations/live-migration.rst
+++ b/how-to/operations/live-migration.rst
@@ -7,8 +7,9 @@ Overview
 An instance migration is the relocation of an instance from one
 hypervisor to another.
 
-[note type=“info”] **Note:** This feature is currently only supported in
-channel ``2023.2/edge`` of the **openstack** snap. [/note]
+.. note::
+   This feature is currently only supported in channel ``2023.2/edge`` of the
+   **openstack** snap.
 
 When an instance has a live migration performed it is not shut down
 during the process. This is useful when there is an imperative to not

--- a/how-to/troubleshooting/inspecting-the-cluster.rst
+++ b/how-to/troubleshooting/inspecting-the-cluster.rst
@@ -38,8 +38,9 @@ with the Juju controller:
 
    sunbeam utils juju-login
 
-[note type=“caution”] The ``juju-login`` command is only available in
-the ``2023.1/edge`` version of the ``openstack`` snap. [/note]
+.. caution::
+   The ``juju-login`` command is only available in the ``2023.1/edge`` version
+   of the ``openstack`` snap.
 
 Controller model
 ~~~~~~~~~~~~~~~~
@@ -79,10 +80,11 @@ The status of this model can be queried using the following command:
 
 This should work from any node in the deployment.
 
-[note type=“caution”] If the storage role is not specified for any nodes
-in the deployment the ``cinder-ceph`` application will remain in a
-blocked state. This is expected and means that the deployed OpenStack
-cloud does not support the block storage service. [/note]
+.. caution::
+   If the storage role is not specified for any nodes in the deployment the
+   ``cinder-ceph`` application will remain in a blocked state. This is expected
+   and means that the deployed OpenStack cloud does not support the block storage
+   service.
 
 OpenStack Hypervisor
 --------------------
@@ -155,9 +157,9 @@ the charm of a particular unit:
 
    sudo k8s kubectl logs --namespace openstack --container charm <pod_name>
 
-[note type=“information”] **Information**: The charm container logs are
-also available through ``juju debug-log -m openstack``, and will be
-present in the sunbeam inspection report. [/note]
+.. note::
+   The charm container logs are also available through ``juju debug-log -m openstack``,
+   and will be present in the sunbeam inspection report.
 
 To fetch the payload logs, use:
 
@@ -226,7 +228,7 @@ To unlock a specific Terraform plan:
 This command may prompt you to confirm unlocking depending on how recent
 the lock timestamp is.
 
-[note type=“caution”] **Caution**: Ensure that there are no
-administrative operations underway in the deployment when unlocking a
-Terraform plan. Otherwise, the deployment’s integrity can be
-compromised. [/note]
+.. caution::
+   Ensure that there are no administrative operations underway in the
+   deployment when unlocking a Terraform plan. Otherwise, the deployment’s
+   integrity can be compromised.

--- a/reference/manifest-file-reference.rst
+++ b/reference/manifest-file-reference.rst
@@ -4,8 +4,9 @@ Manifest file reference
 This resource aims to provide a definitive structure of a deployment
 manifest file will all its supported keys.
 
-[note type=“info”] **Note:** The manifest file is currently only
-supported in channel ``2023.2/edge`` of the **openstack** snap. [/note]
+.. note::
+   The manifest file is currently only supported in channel ``2023.2/edge`` of
+   the **openstack** snap.
 
 .. tip::
    For a conceptual overview of manifests, see the :doc:`Deployment manifest

--- a/reference/network-debugging.rst
+++ b/reference/network-debugging.rst
@@ -6,10 +6,9 @@ cloud’s virtual networking system (OVN). Whether prompted by sheer
 interest or by necessity (an issue has arisen), this page will assist
 you in looking into the internals of your cloud’s networking layer.
 
-[note] **Note:** This page was inspired by `upstream OVN
-documentation <https://docs.ovn.org/en/latest/tutorials/ovn-openstack.html>`__.
-Many OVN troubleshooting techniques can be applied equally to a Sunbeam
-environment. [/note]
+.. note::
+   This page was inspired by `upstream OVN documentation <https://docs.ovn.org/en/latest/tutorials/ovn-openstack.html>`__.
+   Many OVN troubleshooting techniques can be applied equally to a Sunbeam environment.
 
 Contents:
 
@@ -167,9 +166,10 @@ ports, we see that they are used internally for guest metadata:
    | network_id   | 856fe9e3-60bf-4177-bb8b-831f68bb55c0         |
    +--------------+----------------------------------------------+
 
-[note] **Note:** The two metadata ports are marked as down and each of
-the guests floating IP ports is in a ``N/A`` state. In both cases, this
-is normal and not an indication of any kind of problem. [/note]
+.. note::
+   The two metadata ports are marked as down and each of the guests floating IP
+   ports is in a ``N/A`` state. In both cases, this is normal and not an
+   indication of any kind of problem.
 
 These entities are reflected in the configuration of the Northbound DB.
 


### PR DESCRIPTION
The Canonical OpenStack documentation pages contain quite a few instances in which note tags and similar are supposed to be used, however, the synthax is not RST-native, and the tags themselves are not rendered (the documentation pages simply contains that text).

This addresses the issue.

Additionally, fixes a few minor issues.