### PR TITLE
Drop reference to older Sunbeam version

### DIFF
--- a/explanation/deployment-manifest.rst
+++ b/explanation/deployment-manifest.rst
@@ -78,7 +78,7 @@ Here is an example software configuration:
 
      charms:
        glance-k8s:
-         channel: 2023.2/candidate
+         channel: 2024.1/candidate
          revision: 66
          config:
            debug: True

--- a/explanation/service-endpoint-encryption.rst
+++ b/explanation/service-endpoint-encryption.rst
@@ -19,10 +19,6 @@ TLS CA feature
 The TLS CA feature is the method to use for deployments that use a third
 party CA for certificates.
 
-.. caution::
-   This feature is currently only supported in channel ``2023.2/edge`` of the
-   **openstack** snap.
-
 .. tip::
    For a how-to on using the TLS CA feature see :doc:`Implement TLS using a third-party CA
    </how-to/misc/implement-tls-using-a-third-party-ca>`.

--- a/how-to/features/ldap.rst
+++ b/how-to/features/ldap.rst
@@ -6,10 +6,6 @@ This feature integrates the OpenStack
 external LDAP service. Effectively, the feature maps LDAP-based users to
 cloud users via an OpenStack domain.
 
-.. caution::
-   This feature is currently only supported in channel ``2023.2`` of the
-   **openstack** snap.
-
 Enabling LDAP
 -------------
 

--- a/how-to/features/observability.rst
+++ b/how-to/features/observability.rst
@@ -140,10 +140,6 @@ You can now look at the different dashboards configured.
 Dashboard
 ---------
 
-.. note::
-   Dashboard is currently only supported in channel ``2023.2`` of the
-   **:spelling:ignore:`openstack`** snap.
-
 OpenStack Service Overview dashboard
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/how-to/misc/implement-tls-using-a-third-party-ca.rst
+++ b/how-to/misc/implement-tls-using-a-third-party-ca.rst
@@ -9,10 +9,6 @@ Authority for your certificates.
    :doc:`Service endpoint encryption </explanation/service-endpoint-encryption>`
    page.
 
-.. caution::
-   This feature is currently only supported in channel ``2023.2/edge`` of the
-   **openstack** snap.
-
 Enable the TLS CA feature
 -------------------------
 

--- a/how-to/misc/managing-deployment-manifests.rst
+++ b/how-to/misc/managing-deployment-manifests.rst
@@ -1,10 +1,6 @@
 This page shows how to manage deployment manifests. For an overview of
 manifests, see the :doc:`Deployment manifest </explanation/deployment-manifest>` page.
 
-.. caution::
-   This feature is currently only supported in channel ``2023.2/edge`` and
-   later of the **openstack** snap.
-
 .. note::
    Looking to use a manifest from an edge deployment? Take a look at
    `Manifest for non-stable deployments <#manifest-for-non-stable-deployments-4>`__.
@@ -43,9 +39,9 @@ Sample output:
    software:
      charms:
        keystone-k8s:
-         channel: 2023.2/candidate
+         channel: 2024.1/candidate
        glance-k8s:
-         channel: 2023.2/candidate
+         channel: 2024.1/candidate
 
 To get the latest manifest, use the keyword ``latest`` instead of the
 manifest ID:

--- a/how-to/operations/live-migration.rst
+++ b/how-to/operations/live-migration.rst
@@ -7,10 +7,6 @@ Overview
 An instance migration is the relocation of an instance from one
 hypervisor to another.
 
-.. note::
-   This feature is currently only supported in channel ``2023.2/edge`` of the
-   **openstack** snap.
-
 When an instance has a live migration performed it is not shut down
 during the process. This is useful when there is an imperative to not
 interrupt the applications that are running on the instance.

--- a/how-to/troubleshooting/inspecting-the-cluster.rst
+++ b/how-to/troubleshooting/inspecting-the-cluster.rst
@@ -38,10 +38,6 @@ with the Juju controller:
 
    sunbeam utils juju-login
 
-.. caution::
-   The ``juju-login`` command is only available in the ``2023.1/edge`` version
-   of the ``openstack`` snap.
-
 Controller model
 ~~~~~~~~~~~~~~~~
 

--- a/reference/manifest-file-reference.rst
+++ b/reference/manifest-file-reference.rst
@@ -4,10 +4,6 @@ Manifest file reference
 This resource aims to provide a definitive structure of a deployment
 manifest file will all its supported keys.
 
-.. note::
-   The manifest file is currently only supported in channel ``2023.2/edge`` of
-   the **openstack** snap.
-
 .. tip::
    For a conceptual overview of manifests, see the :doc:`Deployment manifest
    </explanation/deployment-manifest>` page.
@@ -131,9 +127,9 @@ manifest file will all its supported keys.
        ...
        # Examples:
        # keystone-k8s:
-       #   channel: 2023.2/candidate
+       #   channel: 2024.1/candidate
        # glance-k8s:
-       #   channel: 2023.2/candidate
+       #   channel: 2024.1/candidate
        #   revision: 66
        #   config:
        #     debug: true


### PR DESCRIPTION
The docs contain a certain number of reference to features that are all present in latest stable version of Sunbeam. Drop unnecessary caution. Drop older reference to antelope/bobcat.