### PR TITLE
Temporarily suspend PDF builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,8 +22,8 @@ sphinx:
   fail_on_warning: true
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
+#formats:
+#   - pdf
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
PDF Builds are hanging on read the docs and needs to be further debugged and diagnosed. This is causing the RTD builds to timeout and fail, which is preventing updates from being published.

This change temporarily removes the PDF builds for the moment to allow an update of docs while the PDF builds are debugged.