### PR TITLE
Renaming doc file and fix paragraph placement

### DIFF
--- a/how-to/misc/using-an-existing-juju-controller.rst
+++ b/how-to/misc/using-an-existing-juju-controller.rst
@@ -1,3 +1,6 @@
+Using an existing Juju controller
+=================================
+
 Canonical OpenStack can use an existing Juju controller during bootstrap
 instead of deploying a Juju controller within the Canonical OpenStack
 deployment.


### PR DESCRIPTION
Fix https://github.com/canonical/canonical-openstack-docs/issues/72
This PR fixes the double entry title by renaming it to reflect the provided content, and also addresses the paragraph placement.
if something needs to be changed please let me know it.