### PR TITLE
sr-iov/dpdk doc updates

### DIFF
--- a/how-to/misc/configuring-dpdk.rst
+++ b/how-to/misc/configuring-dpdk.rst
@@ -245,11 +245,16 @@ ports:
 Disabling DPDK
 --------------
 
-The DPDK feature may be disabled using the following command:
+The DPDK feature may be disabled using the following command. Simply specify
+"n" when prompted in order to disable DPDK.
 
 ::
 
 	sunbeam configure dpdk
+
+	Enable OVS DPDK data path, handling packets in userspace. It provides improved performance compared to
+	the standard OVS kernel data path. DPDK capable network interfaces are required.
+	Enable and configure DPDK [y/n] (y): n
 
 By doing so, the OVS bridges will be set to use the standard system datapath
 instead of ``netdev`` (DPDK).

--- a/how-to/misc/configuring-sriov.rst
+++ b/how-to/misc/configuring-sriov.rst
@@ -343,11 +343,20 @@ bridge:
 Disabling SR-IOV
 ----------------
 
-The same command may also be used to disable the SR-IOV functionality:
+The same command may also be used to disable the SR-IOV functionality.
+Specify "n" for each interface that should no longer be used with SR-IOV.
 
 ::
 
     sunbeam configure sriov
+
+    Found the following SR-IOV capable devices:
+      [ ] Intel Corporation Ethernet Controller X550 (eno1) [physnet: None]
+      [X] Intel Corporation Ethernet Controller X550 (eno2) [physnet: physnet1]
+      [ ] Mellanox Technologies MT27520 Family [ConnectX-3 Pro] (enp94s0) [physnet: None]
+    Add network adapter to PCI whitelist? Intel Corporation Ethernet Controller X550 (eno1)  [y/n] (n): n
+    Add network adapter to PCI whitelist? Intel Corporation Ethernet Controller X550 (eno2)  [y/n] (y): n
+    Add network adapter to PCI whitelist? Mellanox Technologies MT27520 Family [ConnectX-3 Pro] (enp94s0)  [y/n] (n): n
 
 Existing instances will not be modified, consider removing VF attachments
 manually to avoid subsequent port binding failures.


### PR DESCRIPTION
This PR describes the necessary steps to disable the SR-IOV and DPDK features.

At the same time, we'll update bootstrap references since those features are now configured separately.