### PR TITLE
Add Network Role documentation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -64,6 +64,7 @@ Mellanox
 MetalLB
 MicroCeph
 MicroCluster
+MicroOVN
 Multipass
 NATed
 Netplan

--- a/explanation/architecture.rst
+++ b/explanation/architecture.rst
@@ -131,12 +131,25 @@ Nodes with the compute role should be hardware virtualization (KVM) capable
 otherwise user-space emulation is used for instances which has a significant
 performance impact.
 
+.. note::
+   The compute role provides OVN L3 Gateway services. In the future, only Network nodes
+   will provide this functionality.
+
 Storage
 ^^^^^^^
 
 The storage role encapsulates the software defined storage component of the cloud; this is provided by Ceph which provides a massively scalable storage solution using commodity hardware and is deployed in the form MicroCeph.
 
 Nodes with the storage role must have free, un-partitioned disks for use by Ceph.
+
+Network
+^^^^^^^
+
+The network role encapsulates the networking component of the cloud; this is provided by MicroOVN which provides OVN L3 Gateway services.
+.. note::
+
+   The network and compute roles are mutually exclusive: a node assigned the
+   network role must not also be assigned the compute role.
 
 Topology
 --------
@@ -157,14 +170,14 @@ In a single-node deployment, all of the components of the deployed OpenStack Clo
 
 .. Image source: https://assets.ubuntu.com/v1/eac5c9be-Canonical%20OpenStack%20single-node%20topology.png
 
-In a single-node deployment the node will assume control and compute roles by default. Note that the use of the storage role currently requires pristine, un-partitioned block devices on the node being used.
+In a single-node deployment the node will assume control and compute roles by default. Note that the use of the storage role currently requires pristine, un-partitioned block devices on the node being used. The network role is mutually exclusive with the compute role.
 
 It is possible to deploy a single-node cloud with remote access to control plane services and instances - this is the ``remote`` option for instance networking and requires a range of IP addresses for K8s loadbalancer use on the network upon which the node being used resides - see the :doc:`Install Canonical OpenStack using the manual bare metal provider how-to guide</how-to/install/install-canonical-openstack-using-the-manual-bare-metal-provider>` for examples on how to do this.
 
 Multi-node
 ~~~~~~~~~~
 
-Multi-node deployments all start off as single-node deployments; additional nodes are added to the cloud to expand the capacity and resilience of the control plane and add additional capacity and resilience to the compute and storage components.
+Multi-node deployments all start off as single-node deployments; additional nodes are added to the cloud to expand the capacity and resilience of the control plane and add additional capacity and resilience to the compute, storage and network components.
 
 .. figure:: images/multi-node-topology.png
    :align: center

--- a/explanation/maintenance-mode.rst
+++ b/explanation/maintenance-mode.rst
@@ -102,6 +102,11 @@ Verify
     scheduled on the node.
 
 
+Network Role
+~~~~~~~~~~~~
+
+Network role maintenance mode is not supported yet.
+
 Storage Role
 ~~~~~~~~~~~~
 

--- a/explanation/network-traffic-isolation-with-maas.rst
+++ b/explanation/network-traffic-isolation-with-maas.rst
@@ -101,6 +101,9 @@ requirements are described here:
 | storage               | Ceph                  | management, storage,  |
 |                       |                       | storage-cluster       |
 +-----------------------+-----------------------+-----------------------+
+| network               | MicroOVN              | management, internal, |
+|                       |                       | data                  |
++-----------------------+-----------------------+-----------------------+
 
 Client
 ~~~~~~

--- a/how-to/install/install-canonical-openstack-using-canonical-maas.rst
+++ b/how-to/install/install-canonical-openstack-using-canonical-maas.rst
@@ -155,6 +155,9 @@ in the cluster:
    * - storage
      - Defines where to host cloud storage functions
      - Cloud, Storage
+   * - network
+     - Defines where to host cloud network functions
+     - Cloud, Network
    * - sunbeam
      - Defines where to host the Sunbeam controller
      - Sunbeam Controller

--- a/how-to/install/install-canonical-openstack-using-the-manual-bare-metal-provider.rst
+++ b/how-to/install/install-canonical-openstack-using-the-manual-bare-metal-provider.rst
@@ -103,6 +103,10 @@ This will assign all roles (``control``, ``compute``, ``storage``) to the machin
 You can use the ``--role`` switch to narrow them down. See the :doc:`Architecture</explanation/architecture>` section for more
 details.
 
+.. note ::
+
+   A node can also be bootstrapped with the ``network`` role assigned.
+
 When prompted, answer some interactive questions. Below is a sample output from the *cloud-1*
 machine from the :doc:`Example physical configuration </reference/example-physical-configuration>` section:
 
@@ -117,6 +121,12 @@ machine from the :doc:`Example physical configuration </reference/example-physic
 
 You can also refer to the :doc:`Interactive configuration prompts</reference/interactive-configuration-prompts>` section for detailed description of
 each of those questions and some examples.
+
+.. note ::
+
+   The ``network`` role is mutually exclusive with the ``compute`` role and cannot be assigned
+   to the same machine. See the :doc:`Architecture</explanation/architecture>` section for more
+   details.
 
 Also note that answers to all those questions can be automated with the use of a
 :doc:`Deployment manifest</explanation/deployment-manifest>`.

--- a/how-to/misc/managing-deployment-manifests.rst
+++ b/how-to/misc/managing-deployment-manifests.rst
@@ -89,7 +89,7 @@ To specify a manifest during the cluster bootstrap process:
 
 ::
 
-   sunbeam cluster bootstrap [--role <control|compute|storage>] [--manifest <manifest file path>] [--accept-defaults]
+   sunbeam cluster bootstrap [--role <control|compute|network|storage>] [--manifest <manifest file path>] [--accept-defaults]
 
 Cluster refresh
 ~~~~~~~~~~~~~~~

--- a/how-to/operations/removing-the-primary-node.rst
+++ b/how-to/operations/removing-the-primary-node.rst
@@ -67,6 +67,12 @@ Remove the ``k8s`` snap:
 
    sudo snap remove --purge k8s
 
+Remove the ``microovn`` snap:
+
+.. code-block :: text
+
+   sudo snap remove --purge microovn
+
 .. note ::
 
    The above steps can take a few minutes to complete.

--- a/how-to/operations/scaling-the-cluster-out.rst
+++ b/how-to/operations/scaling-the-cluster-out.rst
@@ -102,7 +102,7 @@ In order to add the machine to the cluster, execute the ``sunbeam cluster join``
 
 ``FILE`` is a name of the file with the registration token.
 
-``ROLES``` is a comma-separated list of roles (``control``, ``compute``, ``storage``) to assign to the machine being added.
+``ROLES``` is a comma-separated list of roles (``control``, ``compute``, ``network``, ``storage``) to assign to the machine being added.
 
 For example, to add the *cloud-2* machine from the :doc:`Example physical configuration</reference/example-physical-configuration>` section, execute the following command:
 

--- a/how-to/troubleshooting/inspecting-the-cluster.rst
+++ b/how-to/troubleshooting/inspecting-the-cluster.rst
@@ -52,7 +52,7 @@ this model can be queried using the following command:
 This should work from any node in the deployment
 
 This model contains the application deployments for the Canonical K8s
-(control role), MicroCeph (storage role) and OpenStack Hypervisor
+(control role), MicroOVN (network role), MicroCeph (storage role) and OpenStack Hypervisor
 (compute role) components of Canonical OpenStack.
 
 Depending on the roles assigned to individual machines, a unit of each

--- a/reuse/links.txt
+++ b/reuse/links.txt
@@ -12,6 +12,7 @@
 .. _OpenStack snap: https://snapcraft.io/openstack
 .. _OpenStack Hypervisor snap: https://snapcraft.io/openstack-hypervisor
 .. _MicroCeph snap: https://snapcraft.io/microceph
+.. _MicroOVN snap: https://snapcraft.io/microovn
 
 .. _Canonical Juju: https://juju.is
 .. _Canonical Kubernetes: https://ubuntu.com/kubernetes


### PR DESCRIPTION
This PR updates the documentation to include the network role to sunbeam and adds a new documentation page under `how-to/install` to describe the process of enabling a network node.