### PR TITLE
fix: role argument typo

### DIFF
--- a/how-to/misc/using-an-existing-juju-controller.rst
+++ b/how-to/misc/using-an-existing-juju-controller.rst
@@ -30,7 +30,7 @@ bootstrap:
 
 ::
 
-   sunbeam cluster bootstrap --roles compute,storage,control \
+   sunbeam cluster bootstrap --role compute,storage,control \
        --accept-defaults --controller prod-controller-01
 
 In MAAS mode the roles are determined by tags on the machines being


### PR DESCRIPTION
The correct argument is `role` and not `roles`.