### PR TITLE
Fix the command example in the "Scaling the cluster in" page.

### DIFF
--- a/how-to/operations/scaling-the-cluster-in.rst
+++ b/how-to/operations/scaling-the-cluster-in.rst
@@ -17,7 +17,7 @@ To remove the machine from the cluster, execute the ``sunbeam cluster remove`` c
 
 .. code-block :: text
 
-   sunbeam cluster remove --name FQDN
+   sunbeam cluster remove FQDN
 
 ``FQDN`` is a fully qualified domain name (FQDN) of the machine being removed.
 
@@ -25,7 +25,7 @@ For example, to remove the *cloud-2* machine from the :doc:`Example physical con
 
 .. code-block :: text
 
-   sunbeam cluster remove --name cloud-2.example.com
+   sunbeam cluster remove cloud-2.example.com
 
 Remove components from the machine
 ----------------------------------


### PR DESCRIPTION
This is for this page -> https://canonical-openstack.readthedocs-hosted.com/en/latest/how-to/operations/scaling-the-cluster-in/.

This change updates the command example for removing a command to reflect the current usage of the command. The --name flag is no longer a flag.

The example currently written is:
```
sunbeam cluster remove --name FQDN
```

However, if you run the command like that, you get the following error:
```
~$ sunbeam cluster remove --name some-domain.com
Usage: sunbeam cluster remove [OPTIONS] NAME
Try 'sunbeam cluster remove -h' for help.

Error: No such option: --name
```

The change makes the command example:
```
sunbeam cluster remove FQDN
```