### PR TITLE
maintenance-mode: remove limitation

### DIFF
--- a/explanation/maintenance-mode.rst
+++ b/explanation/maintenance-mode.rst
@@ -69,12 +69,6 @@ Check
   * If there are any instance in **MIGRATING** status, operator should wait until migration
     finished.
 
-  * If there are any instance in **SHUTOFF** status, the maintenance will be blocked, because
-    sunbeam doesn't support cold migration now. This will blocked until we have disable cold
-    migration feature support in watcher. See:
-    https://bugs.launchpad.net/snap-openstack/+bug/2082056 and
-    https://review.opendev.org/c/openstack/watcher-specs/+/943873.
-
 * No ephemeral disks
 
   * Instances with ephemeral disk cannot be migrated, operator should handle it first.

--- a/how-to/operations/maintenance-mode.rst
+++ b/how-to/operations/maintenance-mode.rst
@@ -101,13 +101,3 @@ If the output confirms a safe transition, disable maintenance mode:
 
 .. LINKS
 .. _OpenStack Watcher: https://wiki.openstack.org/wiki/Watcher
-
-
-Known issues
--------------
-
-Cold migration is not supported
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Currently cold migration is not supported in Sunbeam. So maintenance mode pre-flight check will block user to continue if there are any instances in SHUTOFF status.
-This will blocked until upstream watcher support disabling cold migration in host maintenance strategy.

--- a/reference/known-limitations.rst
+++ b/reference/known-limitations.rst
@@ -13,6 +13,6 @@ This document describes the known limitations of the Sunbeam project.
    * - Issue
      - Bug Number
      - Meaning
-   * - **Cold migration is not supported**
-     - `2082056 <https://bugs.launchpad.net/snap-openstack/+bug/2082056>`__
-     - Cold migration of VMs is not supported. This means that if a VM is running on a host, it cannot be moved to another host while being shutdown. Current workaround is to use live migration. This also means resizing instances is not supported.
+   * - None
+     - 
+     - 


### PR DESCRIPTION
Cold migration is supported in sunbeam, so remove
the limitation mentioned in maintenance mode on
not migrating the instances in SHUTDOWN state.