### PR TITLE
Correct command typo in get-familiar tutorial

### DIFF
--- a/tutorial/get-familiar-with-openstack.rst
+++ b/tutorial/get-familiar-with-openstack.rst
@@ -390,7 +390,7 @@ To associate newly created floating IP with the *my_instance_2* VM, execute the 
 
 .. code-block :: text
 
-   IP=$(penstack floating ip list | awk '/None/ { print $4 }')
+   IP=$(openstack floating ip list | awk '/None/ { print $4 }')
    openstack server add floating ip my_instance_2 $IP
 
 Connect to the VM


### PR DESCRIPTION
Fix a misspelling in section "Associate a floating IP address" of the "Get familiar with OpenStack" tutorial.