### PR TITLE
docs: host migration behaviour with disable-migration flag

### DIFF
--- a/explanation/maintenance-mode.rst
+++ b/explanation/maintenance-mode.rst
@@ -78,7 +78,20 @@ Apply
 
 * Audit action plan
 
-  * Execute the watcher audit action plan.
+  * Execute the Watcher audit action plan. By default, the plan will live migrate active
+    instances and cold migrate inactive instances off the node.
+
+  * Operators can control migration behavior using the ``--disable-migration`` flag:
+
+    * ``--disable-migration=live``: Disable live migration. All instances (active and
+      inactive) will be cold migrated.
+    * ``--disable-migration=cold``: Disable cold migration. Active instances will be
+      live migrated; inactive instances will be ignored.
+    * ``--disable-migration=both`` (or ``--disable-migration`` without a value): Disable
+      all migration. Active instances will be stopped; inactive instances will be ignored.
+
+  * This is based on the `Watcher Host Maintenance strategy`_ which supports
+    ``disable_live_migration`` and ``disable_cold_migration`` parameters.
 
 Verify
 ^^^^^^
@@ -283,6 +296,7 @@ Once all roles on the node meet these conditions, the node is considered to be o
 **Maintenance** mode.
 
 .. LINKS
+.. _Watcher Host Maintenance strategy: https://docs.openstack.org/watcher/latest/strategies/host_maintenance.html
 .. _ceph administration tool: https://docs.ceph.com/en/reef/man/8/ceph/
 .. _kubectl drain: https://kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/
 .. _kubectl cordon: https://kubernetes.io/docs/reference/kubectl/generated/kubectl_cordon/

--- a/how-to/operations/maintenance-mode.rst
+++ b/how-to/operations/maintenance-mode.rst
@@ -28,7 +28,7 @@ Before enabling maintenance mode, perform a dry run to check for potential issue
 
 .. code:: text
 
-   sunbeam cluster maintenance enable <node> --dry-run
+   sunbeam cluster maintenance enable <node> [--disable-migration[=live|cold|both]] --dry-run
 
    Continue to run operations to enable maintenance mode for <node>:
            0: change_nova_service_state state=disabled resource=<node>
@@ -41,7 +41,7 @@ If no issues are reported, enable maintenance mode:
 
 .. code:: text
 
-   sunbeam cluster maintenance enable <node>
+   sunbeam cluster maintenance enable <node> [--disable-migration[=live|cold|both]]
 
    Continue to run operations to enable maintenance mode for <node>:
            0: change_nova_service_state state=disabled resource=<node>

--- a/how-to/operations/maintenance-mode.rst
+++ b/how-to/operations/maintenance-mode.rst
@@ -61,6 +61,49 @@ If no issues are reported, enable maintenance mode:
    Enable maintenance for node: <node>
 
 
+Controlling migration behavior
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, enabling maintenance mode will live migrate active instances and cold
+migrate inactive instances. The ``--disable-migration`` flag allows operators to
+control this behavior during maintenance.
+
+.. note::
+
+   If ``--disable-migration`` is not specified, the default behavior is unchanged.
+
+To disable live migration (cold migrate both active and inactive instances):
+
+.. code:: text
+
+   sunbeam cluster maintenance enable <node> --disable-migration=live
+
+To disable cold migration (live migrate active instances, ignore inactive instances):
+
+.. code:: text
+
+   sunbeam cluster maintenance enable <node> --disable-migration=cold
+
+To disable all migration (only stop active instances, ignore inactive instances):
+
+.. code:: text
+
+   sunbeam cluster maintenance enable <node> --disable-migration=both
+
+Or equivalently, without specifying a value:
+
+.. code:: text
+
+   sunbeam cluster maintenance enable <node> --disable-migration
+
+The ``--disable-migration`` flag can be combined with ``--dry-run`` to preview the
+effect before applying:
+
+.. code:: text
+
+   sunbeam cluster maintenance enable <node> --disable-migration=live --dry-run
+
+
 Disabling Maintenance Mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Update the documentation for using the `disable-migration` flag in host maintenance operation, based on https://github.com/canonical/snap-openstack/pull/724