### PR TITLE
Update cloud section in reconfigure-k8s-api-endpoint-juju

### DIFF
--- a/how-to/misc/reconfigure-k8s-api-endpoint-juju.rst
+++ b/how-to/misc/reconfigure-k8s-api-endpoint-juju.rst
@@ -47,6 +47,9 @@ new endpoint address:
        type: kubernetes
        auth-types: [oauth2, clientcertificate]
        endpoint: https://10.4.2.3:16443 # <- new endpoint
+       regions:
+         localhost:
+           endpoint: https://10.4.2.3:16443 # <- new endpoint
 
 Update the controller cloud configuration
 -----------------------------------------


### PR DESCRIPTION
In the example to update cloud, region is not specified. Add region endpoint as well. Without this, the dead pods can get stale region endpoints and pod stays in
CrashLoopBackoff.