### PR TITLE
manifest: Update traefik config-map in manifest reference

### DIFF
--- a/reference/manifest-file-reference.rst
+++ b/reference/manifest-file-reference.rst
@@ -368,6 +368,22 @@ manifest file will all its supported keys.
          #   storage:
          #     local-repository: <value>
 
+         # Configure traefik configs per application
+         # traefik-k8s:
+         #   config-map:
+         #     traefik:
+         #       tls-ca: <value>
+         #       tls-cert: <value>
+         #       tls-key: <value>
+         #     traefik-public:
+         #       tls-ca: <value>
+         #       tls-cert: <value>
+         #       tls-key: <value>
+         #     traefik-rgw:
+         #       tls-ca: <value>
+         #       tls-cert: <value>
+         #       tls-key: <value>
+
        terraform:
          <plan>:
            source: <path-to-file>


### PR DESCRIPTION
traefik config-map allows to update configurations of traefik per application i.e., traefik, traefik-public, traefik-rgw. The example is updated in manifest
reference section

Depends-On: https://github.com/canonical/snap-openstack/pull/792