### PR TITLE
docs: add information about embedded observability storage config

### DIFF
--- a/how-to/features/observability.rst
+++ b/how-to/features/observability.rst
@@ -64,6 +64,13 @@ To enable Observability, run the following command:
 
    sunbeam enable observability embedded
 
+.. note::
+   Storage size for the embedded observability stack can be configured using
+   the :doc:`manifest file </reference/manifest-file-reference>`, which is
+   consumed during the cluster bootstrap or refresh.
+
+   Changing the storage size after deployment is not currently supported.
+
 .. _disabling-observability-1:
 
 Disabling Observability

--- a/reference/manifest-file-reference.rst
+++ b/reference/manifest-file-reference.rst
@@ -377,6 +377,31 @@ manifest file will all its supported keys.
 
    features:
 
+     observability:
+       embedded:
+         # Storage for embedded COS can be configured before deployment.
+         # Resizing these storage options after deployment is not currently
+         # supported.
+         software:
+           charms:
+             <charm>:
+               storage:
+                 <option>: <value>
+             # Examples:
+             # prometheus-k8s:
+             #   storage:
+             #     database: "40G"              # default: 20G
+             # loki-k8s:
+             #   storage:
+             #     active-index-directory: "4G" # default: 2G
+             #     loki-chunks: "10G"           # default: 5G
+             # grafana-k8s:
+             #   storage:
+             #     database: "2G"               # default: 1G
+             # alertmanager-k8s:
+             #   storage:
+             #     data: "2G"                   # default: 1G
+
      loadbalancer:
        config:
          <option>: <value>


### PR DESCRIPTION
Add information about embedded observability storage configuration and its manifest reference.

Put more emphasis that the embedded observability storage cannot be resized after deployed.

Related PR: https://github.com/canonical/snap-openstack/pull/790