### PR TITLE
fix: exclude readme.rst from rendered page and skip Sphinx venv generation

### DIFF
--- a/.github/workflows/sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/sphinx-python-dependency-build-checks.yml
@@ -11,14 +11,14 @@
 # succeed.
 name: Check and document build requirements for Sphinx venv
 on:
-  push:
-    paths:
-      - 'conf.py'
-      - 'custom_conf.py'
-  pull_request:
-    paths:
-      - 'conf.py'
-      - 'custom_conf.py'
+  # push:
+  #   paths:
+  #     - 'conf.py'
+  #     - 'custom_conf.py'
+  # pull_request:
+  #   paths:
+  #     - 'conf.py'
+  #     - 'custom_conf.py'
   workflow_dispatch:
 
 
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -202,7 +202,8 @@ custom_required_modules = [
 # Add files or directories that should be excluded from processing.
 custom_excludes = [
     'doc-cheat-sheet*',
-    ]
+    'readme.rst'
+]
 
 # Add CSS files (located in .sphinx/_static/)
 custom_html_css_files = []


### PR DESCRIPTION
Exclude `readme.rst` from rendered file list and stop Sphinx venv rebuild when configuration files are changed as the CI is no longer maintained.