### PR TITLE
Document Masakari secret decrypt access

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -153,6 +153,7 @@ cron
 daemonset
 datapath
 datastore
+decrypt
 dev
 distro
 dom

--- a/explanation/instance-recovery.rst
+++ b/explanation/instance-recovery.rst
@@ -7,3 +7,11 @@ Each compute node runs a Consul agent which periodically performs a TCP health c
 - The ``nova-compute`` service is disabled.
 
 Masakari checks the status from the Consul server and triggers the recovery. Refer to the recovery matrix in the :doc:`Instance Recovery how-to </how-to/features/instance-recovery>` for when recovery is triggered and whether instances needs to be evacuated.
+
+For VMs with encrypted disks, the recovery workflow may need to retrieve
+Barbican secret payloads. Canonical OpenStack keeps the normal Barbican decrypt
+paths for project administrators, project members, secret owners, non-private
+secrets, and ACLs. It also allows trusted service users in the ``services``
+project to decrypt secrets when they have the ``secret-decrypter`` role. Masakari
+uses this service role by default so it can rebuild encrypted VMs during
+instance recovery.

--- a/how-to/features/instance-recovery.rst
+++ b/how-to/features/instance-recovery.rst
@@ -18,6 +18,10 @@ To enable Instance Recovery, run the following command:
    see :ref:`reference<reserved-ipranges>`.
    This will be used to perform health checks over the storage network.
 
+When :doc:`Secrets </how-to/features/secrets>` is enabled, Masakari is granted
+permission to decrypt Barbican secrets by default. This allows Masakari to
+rebuild VMs with encrypted disks during instance recovery.
+
 Disabling Instance Recovery
 ---------------------------
 
@@ -26,6 +30,34 @@ To disable Instance Recovery, run the following command:
 ::
 
     sunbeam disable instance-recovery
+
+Encrypted disk recovery
+-----------------------
+
+Masakari needs access to Barbican secret payloads to recover VMs that use
+encrypted disks. Canonical OpenStack enables this access by default with the
+``enable-secret-access`` option on the ``masakari-k8s`` charm.
+
+To opt out durably, set the option in the deployment manifest:
+
+.. code:: yaml
+
+    software:
+      charms:
+        masakari-k8s:
+          config:
+            enable-secret-access: false
+
+Apply the updated manifest when enabling, or re-enabling, Instance Recovery:
+
+::
+
+    sunbeam enable --manifest <manifest file path> instance-recovery
+
+Disabling this option stops Masakari from requesting the ``secret-decrypter``
+role. It does not remove existing Keystone role assignments. To audit or remove
+existing assignments, follow :ref:`the Secrets role audit guidance
+<audit-secret-decrypt-access>`.
 
 Instance Evacuation Recovery methods
 ------------------------------------

--- a/how-to/features/secrets.rst
+++ b/how-to/features/secrets.rst
@@ -68,3 +68,41 @@ Retrieve the original secret (``my_payload``) via the secret href value:
    +---------+-------------+
    | Payload | my_payload  |
    +---------+-------------+
+
+.. _audit-secret-decrypt-access:
+
+Audit secret decrypt access
+---------------------------
+
+The ``secret-decrypter`` role allows a service user in the ``services`` project
+to decrypt Barbican secret payloads. Audit users with this role regularly:
+
+::
+
+   openstack role assignment list \
+      --names \
+      --role secret-decrypter \
+      --project services \
+      --project-domain service_domain
+
+Canonical OpenStack grants this role to the Masakari service user by default so
+that instance recovery can rebuild servers with encrypted disks.
+
+Remove secret decrypt access
+----------------------------
+
+Before removing this role, verify that the service user no longer needs to
+decrypt Barbican secrets. For Masakari, disable the role request first with the
+Instance Recovery configuration described in
+:doc:`/how-to/features/instance-recovery`.
+
+For each service user that should no longer have this role, run:
+
+::
+
+   openstack role remove \
+      --user <service-user> \
+      --user-domain service_domain \
+      --project services \
+      --project-domain service_domain \
+      secret-decrypter


### PR DESCRIPTION
Document that Masakari receives Barbican secret decrypt access by default so instance recovery can rebuild VMs with encrypted disks.

Add operator guidance for auditing secret-decrypter role assignments, opting out through a durable deployment manifest, and removing existing Keystone role assignments after opt-out.