### PR TITLE
docs: document observability collector storage

### DIFF
--- a/reference/_include/manifest-file-reference.yaml
+++ b/reference/_include/manifest-file-reference.yaml
@@ -404,6 +404,14 @@ features:
           # alertmanager-k8s:
           #   storage:
           #     data: "2G"                   # default: 1G
+          # opentelemetry-collector-k8s:
+          #   storage:
+          #     persisted: "8G"              # default: 1G
+          #   storage-map:
+          #     opentelemetry-collector:
+          #       persisted: "2G"
+          #     opentelemetry-collector-infra:
+          #       persisted: "3G"
 
   loadbalancer:
     config:


### PR DESCRIPTION
Document how to set embedded observability storage in the deployment manifest.