### PR TITLE
docs: add Horizon–Glance CORS relation guidance for image uploads

### DIFF
--- a/how-to/misc/multiregion-deployments.rst
+++ b/how-to/misc/multiregion-deployments.rst
@@ -125,6 +125,7 @@ defined.
 	juju consume $controller:$owner/openstack.keystone-endpoints
 	juju consume $controller:$owner/openstack.keystone-ops
 	juju consume $controller:$owner/openstack.cert-distributor
+	juju consume $controller:$owner/openstack.horizon-cors-origin
 
 	juju integrate keystone-endpoints cinder:identity-service
 	juju integrate keystone-endpoints glance:identity-service
@@ -137,6 +138,8 @@ defined.
 	juju integrate cert-distributor neutron:receive-ca-cert
 	juju integrate cert-distributor nova:receive-ca-cert
 	juju integrate cert-distributor placement:receive-ca-cert
+
+	juju integrate horizon-cors-origin glance:cors-origin
 
 	# Run the following once Sunbeam reaches the following phase:
 	# ⠸ Deploying OpenStack Hypervisor ...

--- a/how-to/misc/using-the-openstack-dashboard.rst
+++ b/how-to/misc/using-the-openstack-dashboard.rst
@@ -38,5 +38,10 @@ After a successful login, you should see the landing page:
 .. figure:: horizon-overview.png
    :alt: Horizon overview page
 
-You can now start managing your OpenStack cloud (e.g. create additional
+You can now start managing your OpenStack cloud (e.g. create additional
 users, launch server instances, etc.).
+
+.. important::
+   Uploading images via the dashboard requires the browser to have direct
+   access to the Glance public endpoint. Ensure this endpoint is reachable
+   from any machine used to access the dashboard.

--- a/how-to/operations/cluster-upgrades.rst
+++ b/how-to/operations/cluster-upgrades.rst
@@ -133,3 +133,24 @@ stored manifest:
 .. code:: text
 
    sunbeam cluster refresh --clear-manifest
+
+.. _refresh-multi-region:
+
+Multi-region deployments
+-----------------------------------------
+
+In a multi-region deployment, run the following for each secondary region
+after completing the cluster refresh. This adds the ``cors-origin`` relation
+between Horizon on the region controller and Glance in the secondary region,
+which is required for image uploads from the dashboard.
+
+::
+
+	controller="sunbeam-controller-region-controller"
+	# Usually the region controller fqdn
+	owner="$ownerFqdn"
+
+	juju switch openstack
+
+	juju consume $controller:$owner/openstack.horizon-cors-origin
+	juju integrate horizon-cors-origin glance:cors-origin


### PR DESCRIPTION
Changes added as part of resolving [LP #2152186](https://bugs.launchpad.net/snap-openstack/+bug/2152186) require docs to be updated:

- multiregion: document consume/integrate horizon-cors-origin with glance
- upgrades: add post-refresh steps for multi region setups
- dashboard: browser must be able to reach glance public endpoint for uploads

OPEN-4572
