### PR TITLE
OPEN-4593 - Add tags to space mappings

### DIFF
--- a/how-to/install/install-canonical-openstack-using-canonical-maas.rst
+++ b/how-to/install/install-canonical-openstack-using-canonical-maas.rst
@@ -148,27 +148,39 @@ in the cluster:
    * - Machine tag
      - Purpose
      - Nodes to assign the tag to
+     - Required cloud networks
    * - openstack-<name>
      - Defines which machines to use in this particular deployment
      - Cloud, Control, Compute, Storage, Sunbeam Controller, Juju Controller
+     - None
    * - control
      - Defines where to host cloud control functions
      - Cloud, Control
+     - data, internal, management, public, storage
+   * - region-controller
+     - Defines where to host cloud region controller functions
+     - Region Controller
+     - internal, management, public
    * - compute
      - Defines where to host cloud compute functions
      - Cloud, Compute
+     - data, internal, management, storage
    * - storage
      - Defines where to host cloud storage functions
      - Cloud, Storage
+     - internal, management, storage, storage-cluster
    * - network
      - Defines where to host cloud network functions
      - Cloud, Network
+     - internal, management, data
    * - sunbeam
      - Defines where to host the Sunbeam controller
      - Sunbeam Controller
+     - management
    * - juju-controller
      - Defines where to host the Juju controller
      - Juju Controller
+     - management
 
 Note that the ``<name>`` suffix must match the deployment name.
 


### PR DESCRIPTION
## Summary

Adds a `Required Spaces` column to the MAAS machine tags assignment table.

## Changes

- Documented required spaces for:
  - `control`
  - `compute`
  - `storage`
  - `network`
  - `sunbeam`
  - `juju-controller`

[OPEN-4593](https://warthogs.atlassian.net/browse/OPEN-4593)

[OPEN-4593]: https://warthogs.atlassian.net/browse/OPEN-4593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ