### PR TITLE
manifest: Add cinder-volume config-map manifest reference

### DIFF
--- a/reference/_include/manifest-file-reference.yaml
+++ b/reference/_include/manifest-file-reference.yaml
@@ -372,6 +372,14 @@ core:
       #       tls-cert: <value>
       #       tls-key: <value>
 
+      # Configure cinder-volume configs per application
+      # cinder-volume:
+      #   config-map:
+      #     cinder-volume:
+      #       rabbit-user: <value>
+      #     cinder-volume-noha:
+      #       rabbit-user: <value>
+
     terraform:
       <plan>:
         source: <path-to-file>


### PR DESCRIPTION
Add cinder-volume config-map to manifest reference to set separate configs for cinder-volume and cinder-volume-noha

Depends-On:
- [x] https://github.com/canonical/snap-openstack/pull/861