### PR TITLE
docs: add instance-recovery/cluster-refresh snap interface limitation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -182,6 +182,7 @@ idp
 infrastructure
 init
 initiator
+instantiation
 intra
 ippool
 isolCPUs

--- a/how-to/operations/cluster-upgrades.rst
+++ b/how-to/operations/cluster-upgrades.rst
@@ -112,6 +112,12 @@ charms:
 
    sunbeam cluster refresh
 
+.. note::
+   If the ``instance-recovery`` feature is enabled, running a cluster refresh
+   may leave the ``openstack-network-agents`` and ``openstack-hypervisor``
+   charms in a blocked state on compute nodes. See
+   :ref:`Known limitations` for details and the workaround.
+
 If the snap has been refreshed to a different risk level in its channel
 (for example, from ``stable`` to ``beta``) since the last update, the command
 will prompt you to confirm before proceeding. In this case, it is recommended

--- a/reference/known-limitations.rst
+++ b/reference/known-limitations.rst
@@ -19,6 +19,18 @@ This document describes the known limitations of the Sunbeam project.
      - Clusters bootstrapped with ``snap-openstack`` versions earlier than 
        **rev998** will continue to experience intermittent API failures (for up 
        to 5 minutes) when a control node becomes unavailable. A known 
-       `k8s charm limitation <https://charmhub.io/k8s/configurations#kube-apiserver-extra-args>`_ 
-       restricts updates on active deployments, meaning this issue cannot be 
+       `k8s charm limitation <https://charmhub.io/k8s/configurations#kube-apiserver-extra-args>`_
+       restricts updates on active deployments, meaning this issue cannot be
        fixed on clusters deployed prior to this revision.
+   * - Enabling the instance-recovery feature blocks the
+       openstack-network-agents and openstack-hypervisor charms
+     - `LP #2147411 <https://bugs.launchpad.net/snap-openstack/+bug/2147411>`_
+     - Enabling the ``instance-recovery`` feature can leave the
+       ``openstack-network-agents`` and ``openstack-hypervisor`` charms in a
+       blocked state on compute nodes, as the parallel instantiation of
+       consul-client snaps disrupts the snap interface connections to
+       MicroOVN ``ovn-chassis`` endpoint. As a workaround, disconnect and
+       reconnect the ``ovn-chassis`` interface on the
+       ``openstack-network-agents`` and ``openstack-hypervisor`` snaps, or
+       reboot the affected host. This issue can also be triggered by running
+       a Sunbeam cluster refresh.


### PR DESCRIPTION
Document LP #2147411 in the known limitations reference, noting that enabling the instance-recovery feature or running a Sunbeam cluster refresh can leave the openstack-network-agents and openstack-hypervisor charms in a blocked state on compute nodes. Add a cross-reference note in the cluster upgrades how-to, scoped to deployments with instance-recovery enabled.