### PR TITLE
fix: Use the correct link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Automatic doc checks](https://github.com/canonical/canonical-openstack-docs/actions/workflows/automatic-doc-checks.yml/badge.svg)](https://github.com/canonical/canonical-openstack-docs/actions/workflows/automatic-doc-checks.yml)
 
-This repository contains the source for the [Canonical OpenStack documentation](https://canonical-openstack.readthedocs.io/).
+This repository contains the source for the [Canonical OpenStack documentation](https://canonical-openstack.readthedocs-hosted.com/en/latest/).
 
 Canonical OpenStack is an enterprise-grade cloud platform that delivers distilled upstream OpenStack excellence in a human-friendly product. It provides elastic, on-demand compute, network, and storage resources through a self-service portal or upstream OpenStack APIs.
 


### PR DESCRIPTION
The link in the README.md pointed to the readthedocs.io domain but the actual documentation link can be found at:

https://canonical-openstack.readthedocs-hosted.com/en/latest/