### PR TITLE
docs: add snap-cinder-volume to the core projects list

### DIFF
--- a/docs/reference/underlying-projects-and-charms.rst
+++ b/docs/reference/underlying-projects-and-charms.rst
@@ -28,6 +28,9 @@ Core
   * - Openstack Hypervisor Snap
     - `Source <https://github.com/canonical/snap-openstack-hypervisor.git>`__
     - `Bugs <https://bugs.launchpad.net/snap-openstack-hypervisor>`__
+  * - Cinder Volume Snap
+    - `Source <https://github.com/canonical/snap-cinder-volume.git>`__
+    - `Bugs <https://bugs.launchpad.net/snap-cinder-volume>`__
   * - RabbitMQ Charm
     - `Source <https://github.com/openstack-charmers/charm-rabbitmq-k8s.git>`__
     - `Bugs <https://bugs.launchpad.net/charm-rabbitmq-k8s>`__


### PR DESCRIPTION
This PR adds snap-cinder-volume to the core projects list.