### PR TITLE
fix: specify terraform failure log location

### DIFF
--- a/docs/how-to/misc/configuring-gpu-passthrough.rst
+++ b/docs/how-to/misc/configuring-gpu-passthrough.rst
@@ -29,10 +29,10 @@ classes`_ of type Display Controller (0x03) and Processing Accelerators (0x1200)
 are filtered as GPU devices. The devices are automatically added to
 `Nova PCI passthrough list`_ and no user intervention is required.
 
-Maas mode
+MAAS mode
 ---------
 
-Maas mode works similar to Manual mode and the detected GPU devices are added
+MAAS mode works similar to Manual mode and the detected GPU devices are added
 to `Nova PCI passthrough list`_ with no user intervention.
 
 Ensure that MAAS is configured to apply the necessary kernel parameters.

--- a/docs/how-to/troubleshooting/inspecting-the-cluster.rst
+++ b/docs/how-to/troubleshooting/inspecting-the-cluster.rst
@@ -235,3 +235,13 @@ the lock timestamp is.
    Ensure that there are no administrative operations underway in the
    deployment when unlocking a Terraform plan. Otherwise, the deployment’s
    integrity can be compromised.
+
+Logs from running Terraform can be found in:
+
+::
+
+    $HOME/snap/openstack/common/etc/<cloud_name>/*/terraform-*.log
+
+.. note::
+    cloud_name is the name of the juju cloud created when bootstrapping sunbeam.
+    It is usually the only directory in $HOME/snap/openstack/common/etc/.

--- a/docs/reference/_include/manifest-file-reference.yaml
+++ b/docs/reference/_include/manifest-file-reference.yaml
@@ -220,7 +220,7 @@ core:
       # external routing
       physnet: <physnet-name>
 
-    # External networking (deprecated, use external_networks instead)
+    # External networking (deprecated, use external-networks instead)
     external_network:
       nic: <interface-name> # deprecated
       nics:


### PR DESCRIPTION
Fix LP 2163607 by adding the location of terraform log files to our documentation.

Fix LP 2163606 by replacing underscore with a dash in deprecation notice.

Drive by to update capitalization of Canonical product names per `make vale`. The other instances not changed were correct as they were juju unit names or included in a link and should not change.

Tested output change by running `make html serve`.

OPEN-4682
OPEN-4683
